### PR TITLE
Remove rank command

### DIFF
--- a/thefutbot.py
+++ b/thefutbot.py
@@ -245,9 +245,6 @@ def c_placar(update: Update, context: CallbackContext) -> None:
 
     return PLACARINPUT
 
-def c_get_ranks(update: Update, context: CallbackContext) -> None:
-    update.message.reply_markdown_v2(sub(r'[()]', '', messages.show_ranks(futdatabase.get_ranks())))
-
 
 def r_placar(update: Update, context: CallbackContext) -> int:
     text = int(update.message.text)


### PR DESCRIPTION
Some players are feeling embarrassed by their rating being show to everyone, so I'm removing this. We should support sportsmanship and the well being of the players, specially mental well being. 